### PR TITLE
update ds.cbind/cbindDS pair

### DIFF
--- a/R/ds.cbind.R
+++ b/R/ds.cbind.R
@@ -1,27 +1,33 @@
 #' @title Combines R objects by columns in the server-side
-#' @description Take a sequence of vector, matrix or data-frame arguments
-#' and combine them by column to produce a matrix.
+#' @description Takes a sequence of vector, matrix or data-frame arguments
+#' and combines them by column to produce a data-frame.
 #' @details A sequence of vector, matrix or data-frame arguments
-#' is combined column by column to produce a matrix 
-#' that is written to the server-side. 
+#' is combined column by column to produce a data-frame that is written to the server-side. 
 #' 
-#' This function is similar to the native function \code{cbind}.
+#' This function is similar to the native R function \code{cbind}.
 #' 
 #' In \code{DataSHIELD.checks} the checks are relatively slow. 
-#' Default \code{DataSHIELD.checks} value is FALSE. 
+#' Default \code{DataSHIELD.checks} value is FALSE.
 #' 
-#' If \code{force.colnames} is NULL column names are inferred from the names or column names
-#' of the first object specified in the \code{x} argument.
-#' The vector of column names must have the same number of elements as 
-#' the columns in the output object. 
+#' If \code{force.colnames} is NULL (which is reccommended), the column names are inferred
+#' from the names or column names of the first object specified in the \code{x} argument.
+#' If this argument is not NULL, then the column names of the assigned data.frame have the
+#' same order as the characters specified by the user in this argument. Therefore, the
+#' vector of \code{force.colnames} must have the same number of elements as the columns in
+#' the output object. In a multi-site DataSHIELD setting to use this argument, the user should
+#' make sure that each study has the same number of names and column names of the input elements
+#' specified in the \code{x} argument and in the same order in all the studies. 
 #' 
 #' Server function called: \code{cbindDS}
 #' 
 #' @param x a character vector with the  name of the objects to be combined.
-#' @param DataSHIELD.checks logical, if TRUE checks that all
-#' input objects exist and are of an appropriate class.
-#' @param force.colnames can be NULL or a vector of characters that specifies 
-#' column names of the output object.
+#' @param DataSHIELD.checks logical, by defauls is FALSE, but if TRUE does four checks: 
+#' 1. the input object(s) is(are) defined in all the studies
+#' 2. the input object(s) is(are) of the same legal class in all the studies
+#' 3. if there are any duplicated column names in the input objects in each study
+#' 4. the number of rows is the same in all componets to be cbind
+#' @param force.colnames can be NULL (recommended) or a vector of characters that specifies 
+#' column names of the output object. If is not NULL the user should take some caution - see Details.
 #' @param newobj a character string that provides the name for the output variable 
 #' that is stored on the data servers. Defaults \code{cbind.newobj}. 
 #' @param datasources a list of \code{\link{DSConnection-class}} objects obtained after login. 
@@ -29,7 +35,7 @@
 #' the default set of connections will be used: see \code{\link{datashield.connections_default}}.
 #' @param notify.of.progress specifies if console output should be produced to indicate
 #' progress. Default FALSE.
-#' @return \code{ds.cbind} returns a matrix combining the columns of the R 
+#' @return \code{ds.cbind} returns a data frame combining the columns of the R 
 #' objects specified in the function which is written to the server-side. 
 #' It also returns to the client-side two messages with the name of \code{newobj}
 #' that has been created in each data source and \code{DataSHIELD.checks} result. 
@@ -62,24 +68,35 @@
 #'   # Log onto the remote Opal training servers
 #'   connections <- DSI::datashield.login(logins = logindata, assign = TRUE, symbol = "D") 
 #' 
-#'   #Combining R objects by columns 
-#'     ds.cbind(x = "D", #data frames in the server-side to be conbined
-#'                       #(see above the connection to the Opal servers)
-#'              DataSHIELD.checks = FALSE,
-#'              force.colnames = NULL,
-#'              newobj = "D.cbind",
-#'              datasources = connections,
-#'              notify.of.progress = FALSE)# All Opal servers are used 
-#'                                         #(see above the connection to the Opal servers)
-#'    
+#'   # Example 1: Assign the exponent of a numeric variable at each server and cbind it 
+#'   # to the dataframe D
+#'   ds.exp(x = "D$LAB_HDL", newobj = "LAB_HDL.exp", datasources = connections) 
+#'   ds.cbind(x = c("D", "LAB_HDL.exp"), DataSHIELD.checks = FALSE,
+#'              newobj = "D.cbind.1", datasources = connections)
+#'              
+#'   # Example 2: If there are duplicated column names in the input objects the function adds
+#'   # a suffix '.k' to the kth replicate". If also the argument DataSHIELD.checks is set to TRUE
+#'   # the function returns a warning message notifying the user for the existence of any duplicated
+#'   # column names in each study
+#'   ds.cbind(x = c("exp", "exp"), DataSHIELD.checks = TRUE,
+#'              newobj = "D.cbind.2", datasources = connections)
+#'   ds.colnames(x = "D.cbind.2", datasources = connections)            
+#'              
+#'   # Example 3: Generate a random normally distributed variable of length 100 at each study,
+#'   # and cbind it to the dataframe D. This example fails and  returns an error as the length
+#'   # of the generated variable "norm.var" is not the same as the number of rows in the dataframe D
+#'   ds.rNorm(samp.size = 100, newobj = "norm.var", datasources = connections) 
+#'   ds.cbind(x = c("D", "norm.var"), DataSHIELD.checks = FALSE,
+#'              newobj = "D.cbind.3", datasources = connections)                 
 #'                    
 #'   # Clear the Datashield R sessions and logout  
 #'   datashield.logout(connections) 
 #'   }
 #' 
-#' @author DataSHIELD Development Team
+#' @author Paul Burton and Demetris Avraam for DataSHIELD Development Team
 #' @export
-ds.cbind<-function(x=NULL,DataSHIELD.checks=FALSE,force.colnames=NULL,newobj=NULL,datasources=NULL,notify.of.progress=FALSE){
+#' 
+ds.cbind <- function(x=NULL, DataSHIELD.checks=FALSE, newobj=NULL, datasources=NULL, notify.of.progress=FALSE){
 
   # look for DS connections
   if(is.null(datasources)){
@@ -96,199 +113,174 @@ ds.cbind<-function(x=NULL,DataSHIELD.checks=FALSE,force.colnames=NULL,newobj=NUL
   xnames <- extract(x)
   varnames <- xnames$elements
   obj2lookfor <- xnames$holders
-
-if(DataSHIELD.checks)
-{
-  # check if the input object(s) is(are) defined in all the studies
-  for(i in 1:length(varnames)){
-    if(is.na(obj2lookfor[i])){
-      defined <- isDefined(datasources, varnames[i])
-    }else{
-      defined <- isDefined(datasources, obj2lookfor[i])
+  
+  if(DataSHIELD.checks){
+    
+    # check if the input object(s) is(are) defined in all the studies
+    for(i in 1:length(varnames)){
+      if(is.na(obj2lookfor[i])){
+        defined <- isDefined(datasources, varnames[i])
+      }else{
+        defined <- isDefined(datasources, obj2lookfor[i])
+      }
     }
-  }
-
-  # call the internal function that checks the input object(s) is(are) of the same legal class in all studies.
-  for(i in 1:length(x)){
-    typ <- checkClass(datasources, x[i])
-    if(!('data.frame' %in% typ) & !('matrix' %in% typ) & !('factor' %in% typ) & !('character' %in% typ) & !('numeric' %in% typ) & !('integer' %in% typ) & !('logical' %in% typ)){
-      stop(" Only objects of type 'data.frame', 'matrix', 'numeric', 'integer', 'character', 'factor' and 'logical' are allowed.", call.=FALSE)
+    
+    # call the internal function that checks the input object(s) is(are) of the same legal class in all studies.
+    for(i in 1:length(x)){
+      typ <- checkClass(datasources, x[i])
+      if(!('data.frame' %in% typ) & !('matrix' %in% typ) & !('factor' %in% typ) & !('character' %in% typ) & !('numeric' %in% typ) & !('integer' %in% typ) & !('logical' %in% typ)){
+        stop("Only objects of type 'data.frame', 'matrix', 'numeric', 'integer', 'character', 'factor' and 'logical' are allowed.", call.=FALSE)
+      }
     }
+    
+    # check that there are no duplicated column names in the input components
+    for(j in 1:length(datasources)){
+      colNames <- list()
+      for(i in 1:length(x)){
+        typ <- checkClass(datasources, x[i])
+        if(typ %in% c('data.frame', 'matrix')){
+          colNames[[i]] <- ds.colnames(x=x[i], datasources=datasources[j])
+        }
+        if(typ %in% c('factor', 'character', 'numeric', 'integer', 'logical')){
+          colNames[[i]] <- as.character(x[i])
+        }
+        colNames <- unlist(colNames)
+        if(anyDuplicated(colNames) != 0){
+          cat("\n Warning: Some column names in study", j, "are duplicated and a suffix '.k' will be added to the kth replicate \n")
+        }  
+      }  
+    } 
+    
+    # check that the number of rows is the same in all componets to be cbind
+    nrows <- c()
+    for(i in 1:length(x)){
+      typ <- checkClass(datasources, x[i])
+      if(typ %in% c('data.frame', 'matrix')){
+        nrows[i] <- ds.dim(x=x[i], type='split', datasources=datasources[i])[[1]][1]
+      }
+      if(typ %in% c('factor', 'character', 'numeric', 'integer', 'logical')){
+        nrows[i] <- ds.length(x[i], type='split', datasources=datasources[i])[[1]]
+      }
+    }
+    if(any(nrows != nrows[1])){
+      stop("The number of rows is not the same in all of the components to be cbind", call.=FALSE)
+    }
+    
   }
-}
+  
   # check newobj not actively declared as null
   if(is.null(newobj)){
     newobj <- "cbind.newobj"
   }
+  
+  # CREATE THE VECTOR OF COLUMN NAMES
+  colname.list <- list()
+  for (std in 1:length(datasources)){  
+    colname.vector <- NULL
+    class.vector <- NULL
+    for(j in 1:length(x)){
+      testclass.var <- x[j]
+      calltext1 <- call('classDS', testclass.var)
+      next.class <- DSI::datashield.aggregate(datasources[std], calltext1)
+      class.vector <- c(class.vector, next.class[[1]])
+      if (notify.of.progress){
+        cat("\n",j," of ", length(x), " elements to combine in step 1 of 2 in study ", std, "\n")
+      }  
+    }
+    for(j in 1:length(x)){
+      test.df <- x[j]
+      if(class.vector[j]!="data.frame" && class.vector[j]!="matrix"){
+        colname.vector <- c(colname.vector, test.df)
+        if (notify.of.progress){
+          cat("\n",j," of ", length(x), " elements to combine in step 2 of 2 in study ", std, "\n")
+        }  
+      }else{
+        calltext2 <- call('colnamesDS', test.df)
+        df.names <- DSI::datashield.aggregate(datasources[std], calltext2)
+        colname.vector <- c(colname.vector, df.names[[1]])
+        if (notify.of.progress){
+          cat("\n", j," of ", length(x), " elements to combine in step 2 of 2 in study ", std, "\n")
+        }  
+      }
+    }
+    colname.list[[std]] <- colname.vector
+  }
+    
+  if (notify.of.progress){
+    cat("\nBoth steps in all studies completed\n")
+  }
+    
+  # prepare name vectors for transmission
+  x.names.transmit <- paste(x, collapse=",")
+  colnames.transmit <- list()
+  for (std in 1:length(datasources)){
+    colnames.transmit[[std]] <- paste(colname.list[[std]], collapse=",")
+  }
+  
+  ###############################
+  # call the server side function
+  for(std in 1:length(datasources)){
+    calltext <- call("cbindDS", x.names.transmit, colnames.transmit[[std]])
+    DSI::datashield.assign(datasources[std], newobj, calltext)
+  }
+  
+  #############################################################################################################
+  # DataSHIELD CLIENTSIDE MODULE: CHECK KEY DATA OBJECTS SUCCESSFULLY CREATED  
+  
+  # SET APPROPRIATE PARAMETERS FOR THIS PARTICULAR FUNCTION 
+  test.obj.name <- newobj	
+  
+  # CALL SEVERSIDE FUNCTION
+  calltext <- call("testObjExistsDS", test.obj.name)
+  object.info <- DSI::datashield.aggregate(datasources, calltext)
 
+  # CHECK IN EACH SOURCE WHETHER OBJECT NAME EXISTS
+  # AND WHETHER OBJECT PHYSICALLY EXISTS WITH A NON-NULL CLASS
+  num.datasources <- length(object.info)
+  
+  obj.name.exists.in.all.sources <- TRUE
+  obj.non.null.in.all.sources <- TRUE
 
-#CREATE THE VECTOR OF COLUMN NAMES
-if(!is.null(force.colnames)){
-colname.vector<-force.colnames
-}else{
+  for(j in 1:num.datasources){
+  	if(!object.info[[j]]$test.obj.exists){
+  		obj.name.exists.in.all.sources <- FALSE
+  	}
+  	if(is.null(object.info[[j]]$test.obj.class) || object.info[[j]]$test.obj.class=="ABSENT"){
+  		obj.non.null.in.all.sources <- FALSE
+  	}
+  }
 
-  colname.vector<-NULL
-  class.vector<-NULL
-
-for(j in 1:length(x))
-{
-testclass.var<-x[j]
-
-calltext1<-call('classDS', testclass.var)
-next.class <- DSI::datashield.aggregate(datasources, calltext1)
-class.vector<-c(class.vector,next.class[[1]])
-if (notify.of.progress)
-    cat("\n",j," of ", length(x), " elements to combine in step 1 of 2\n")
-}
-
-for(j in 1:length(x))
-{
-test.df<-x[j]
-
-if(class.vector[j]!="data.frame" && class.vector[j]!="matrix")
-	{
-	colname.vector<-c(colname.vector,test.df)
-        if (notify.of.progress)
-            cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n")
+  if(obj.name.exists.in.all.sources && obj.non.null.in.all.sources){
+		return.message <- paste0("A data object <", test.obj.name, "> has been created in all specified data sources")
+	}else{
+    return.message.1 <- paste0("Error: A valid data object <", test.obj.name, "> does NOT exist in ALL specified data sources")
+  	return.message.2 <- paste0("It is either ABSENT and/or has no valid content/class,see return.info above")	
+  	return.message.3 <-	paste0("Please use ds.ls() to identify where missing")
+  	return.message <- list(return.message.1,return.message.2,return.message.3)
 	}
-else
-	{
-	calltext2<-paste0('colnames(', test.df, ')')
-    df.names <- DSI::datashield.aggregate(datasources, as.symbol(calltext2))
-	 colname.vector<-c(colname.vector,df.names[[1]])
-         if (notify.of.progress)
-             cat("\n",j," of ", length(x), " elements to combine in step 2 of 2\n")
-	}
-}
-if (notify.of.progress)
-    cat("\nBoth steps completed\n")
 
-#CHECK FOR DUPLICATE NAMES IN COLUMN NAME VECTOR AND ADD ".k" TO THE kth REPLICATE
-num.duplicates<-rep(0,length(colname.vector))
-
-if(length(colname.vector)==1){
-num.duplicates<-0
-}else{
-if(length(colname.vector>=2))
-{
-for(j in length(colname.vector):2)
-{
-	for(k in (j-1):1)
-	{
-	if(colname.vector[j]==colname.vector[k])
-		{
-		num.duplicates[j]<-num.duplicates[j]+1
+	calltext <- call("messageDS", test.obj.name)
+  studyside.message <- DSI::datashield.aggregate(datasources, calltext)
+	no.errors <- TRUE
+	for(nd in 1:num.datasources){
+		if(studyside.message[[nd]]!="ALL OK: there are no studysideMessage(s) on this datasource"){
+		no.errors <- FALSE
 		}
 	}
-}
-}
-}
-num.duplicates.c<-as.character(num.duplicates)
-
-
-
-
-for(m in 1:length(colname.vector))
-{
-if(num.duplicates[m]!="0")
-	{
-
-	colname.vector[m]<-paste0(colname.vector[m],".",num.duplicates.c[m])
+	
+	if(no.errors){
+	  validity.check <- paste0("<",test.obj.name, "> appears valid in all sources")
+	  return(list(is.object.created=return.message,validity.check=validity.check))
 	}
-}
-}
 
-#prepare name vectors for transmission
- x.names.transmit<-paste(x,collapse=",")
- colnames.transmit<-paste(colname.vector,collapse=",")
-
- ###############################
- # call the server side function
-
-
-
-	calltext <- call("cbindDS", x.names.transmit, colnames.transmit)
-
-
-	DSI::datashield.assign(datasources, newobj, calltext)
-
-
-#############################################################################################################
-#DataSHIELD CLIENTSIDE MODULE: CHECK KEY DATA OBJECTS SUCCESSFULLY CREATED                                  #
-													    #
-#SET APPROPRIATE PARAMETERS FOR THIS PARTICULAR FUNCTION                                                    #
-test.obj.name<-newobj											    #
-													    #
-													    #
-													    #
-# CALL SEVERSIDE FUNCTION                                                                                   #
-calltext <- call("testObjExistsDS", test.obj.name)							    #
-													    #
-object.info<-DSI::datashield.aggregate(datasources, calltext)						    #
-													    #
-# CHECK IN EACH SOURCE WHETHER OBJECT NAME EXISTS							    #
-# AND WHETHER OBJECT PHYSICALLY EXISTS WITH A NON-NULL CLASS						    #
-num.datasources<-length(object.info)									    #
-													    #
-													    #
-obj.name.exists.in.all.sources<-TRUE									    #
-obj.non.null.in.all.sources<-TRUE									    #
-													    #
-for(j in 1:num.datasources){										    #
-	if(!object.info[[j]]$test.obj.exists){								    #
-		obj.name.exists.in.all.sources<-FALSE							    #
-		}											    #
-	if(is.null(object.info[[j]]$test.obj.class) || object.info[[j]]$test.obj.class=="ABSENT"){						            #
-		obj.non.null.in.all.sources<-FALSE						            #
-		}																								 	#
-	}																									 	#
-																											#
-if(obj.name.exists.in.all.sources && obj.non.null.in.all.sources){										 	#
-																											#
-	return.message<-																					 	#
-    paste0("A data object <", test.obj.name, "> has been created in all specified data sources")		 	#
-																											#
-																											#
-	}else{																								 	#
-																											#
-    return.message.1<-																					 	#
-	paste0("Error: A valid data object <", test.obj.name, "> does NOT exist in ALL specified data sources")	#
-																											#
-	return.message.2<-																					 	#
-	paste0("It is either ABSENT and/or has no valid content/class,see return.info above")				 	#
-																											#
-	return.message.3<-																					 	#
-	paste0("Please use ds.ls() to identify where missing")												 	#
-																											#
-																											#
-	return.message<-list(return.message.1,return.message.2,return.message.3)							 	#
-																											#
-	}																										#
-																											#
-	calltext <- call("messageDS", test.obj.name)															#
-    studyside.message<-DSI::datashield.aggregate(datasources, calltext)											#
-																											#
-	no.errors<-TRUE																							#
-	for(nd in 1:num.datasources){																			#
-		if(studyside.message[[nd]]!="ALL OK: there are no studysideMessage(s) on this datasource"){			#
-		no.errors<-FALSE																					#
-		}																									#
-	}																										#
-																											#
-																											#
-	if(no.errors){																							#
-	validity.check<-paste0("<",test.obj.name, "> appears valid in all sources")							    #
-	return(list(is.object.created=return.message,validity.check=validity.check))						    #
-	}																										#
-																											#
-if(!no.errors){																								#
-	validity.check<-paste0("<",test.obj.name,"> invalid in at least one source. See studyside.messages:")   #
-	return(list(is.object.created=return.message,validity.check=validity.check,					    		#
-	            studyside.messages=studyside.message))			                                            #
-	}																										#
-																											#
-#END OF CHECK OBJECT CREATED CORECTLY MODULE															 	#
-#############################################################################################################
+  if(!no.errors){
+	  validity.check <- paste0("<",test.obj.name,"> invalid in at least one source. See studyside.messages:")
+	  return(list(is.object.created=return.message,validity.check=validity.check,
+	            studyside.messages=studyside.message))
+  }
+	
+  # END OF CHECK OBJECT CREATED CORECTLY MODULE	
+  #######################################################################################################
 
 }
 #ds.cbind

--- a/man/ds.cbind.Rd
+++ b/man/ds.cbind.Rd
@@ -7,7 +7,6 @@
 ds.cbind(
   x = NULL,
   DataSHIELD.checks = FALSE,
-  force.colnames = NULL,
   newobj = NULL,
   datasources = NULL,
   notify.of.progress = FALSE
@@ -16,11 +15,11 @@ ds.cbind(
 \arguments{
 \item{x}{a character vector with the  name of the objects to be combined.}
 
-\item{DataSHIELD.checks}{logical, if TRUE checks that all
-input objects exist and are of an appropriate class.}
-
-\item{force.colnames}{can be NULL or a vector of characters that specifies 
-column names of the output object.}
+\item{DataSHIELD.checks}{logical, by defauls is FALSE, but if TRUE does four checks: 
+1. the input object(s) is(are) defined in all the studies
+2. the input object(s) is(are) of the same legal class in all the studies
+3. if there are any duplicated column names in the input objects in each study
+4. the number of rows is the same in all componets to be cbind}
 
 \item{newobj}{a character string that provides the name for the output variable 
 that is stored on the data servers. Defaults \code{cbind.newobj}.}
@@ -31,31 +30,37 @@ the default set of connections will be used: see \code{\link{datashield.connecti
 
 \item{notify.of.progress}{specifies if console output should be produced to indicate
 progress. Default FALSE.}
+
+\item{force.colnames}{can be NULL (recommended) or a vector of characters that specifies 
+column names of the output object. If is not NULL the user should take some caution - see Details.}
 }
 \value{
-\code{ds.cbind} returns a matrix combining the columns of the R 
+\code{ds.cbind} returns a data frame combining the columns of the R 
 objects specified in the function which is written to the server-side. 
 It also returns to the client-side two messages with the name of \code{newobj}
 that has been created in each data source and \code{DataSHIELD.checks} result.
 }
 \description{
-Take a sequence of vector, matrix or data-frame arguments
-and combine them by column to produce a matrix.
+Takes a sequence of vector, matrix or data-frame arguments
+and combines them by column to produce a data-frame.
 }
 \details{
 A sequence of vector, matrix or data-frame arguments
-is combined column by column to produce a matrix 
-that is written to the server-side. 
+is combined column by column to produce a data-frame that is written to the server-side. 
 
-This function is similar to the native function \code{cbind}.
+This function is similar to the native R function \code{cbind}.
 
 In \code{DataSHIELD.checks} the checks are relatively slow. 
-Default \code{DataSHIELD.checks} value is FALSE. 
+Default \code{DataSHIELD.checks} value is FALSE.
 
-If \code{force.colnames} is NULL column names are inferred from the names or column names
-of the first object specified in the \code{x} argument.
-The vector of column names must have the same number of elements as 
-the columns in the output object. 
+If \code{force.colnames} is NULL (which is reccommended), the column names are inferred
+from the names or column names of the first object specified in the \code{x} argument.
+If this argument is not NULL, then the column names of the assigned data.frame have the
+same order as the characters specified by the user in this argument. Therefore, the
+vector of \code{force.colnames} must have the same number of elements as the columns in
+the output object. In a multi-site DataSHIELD setting to use this argument, the user should
+make sure that each study has the same number of names and column names of the input elements
+specified in the \code{x} argument and in the same order in all the studies. 
 
 Server function called: \code{cbindDS}
 }
@@ -88,16 +93,26 @@ Server function called: \code{cbindDS}
   # Log onto the remote Opal training servers
   connections <- DSI::datashield.login(logins = logindata, assign = TRUE, symbol = "D") 
 
-  #Combining R objects by columns 
-    ds.cbind(x = "D", #data frames in the server-side to be conbined
-                      #(see above the connection to the Opal servers)
-             DataSHIELD.checks = FALSE,
-             force.colnames = NULL,
-             newobj = "D.cbind",
-             datasources = connections,
-             notify.of.progress = FALSE)# All Opal servers are used 
-                                        #(see above the connection to the Opal servers)
-   
+  # Example 1: Assign the exponent of a numeric variable at each server and cbind it 
+  # to the dataframe D
+  ds.exp(x = "D$LAB_HDL", newobj = "LAB_HDL.exp", datasources = connections) 
+  ds.cbind(x = c("D", "LAB_HDL.exp"), DataSHIELD.checks = FALSE,
+             newobj = "D.cbind.1", datasources = connections)
+             
+  # Example 2: If there are duplicated column names in the input objects the function adds
+  # a suffix '.k' to the kth replicate". If also the argument DataSHIELD.checks is set to TRUE
+  # the function returns a warning message notifying the user for the existence of any duplicated
+  # column names in each study
+  ds.cbind(x = c("exp", "exp"), DataSHIELD.checks = TRUE,
+             newobj = "D.cbind.2", datasources = connections)
+  ds.colnames(x = "D.cbind.2", datasources = connections)            
+             
+  # Example 3: Generate a random normally distributed variable of length 100 at each study,
+  # and cbind it to the dataframe D. This example fails and  returns an error as the length
+  # of the generated variable "norm.var" is not the same as the number of rows in the dataframe D
+  ds.rNorm(samp.size = 100, newobj = "norm.var", datasources = connections) 
+  ds.cbind(x = c("D", "norm.var"), DataSHIELD.checks = FALSE,
+             newobj = "D.cbind.3", datasources = connections)                 
                    
   # Clear the Datashield R sessions and logout  
   datashield.logout(connections) 
@@ -105,5 +120,5 @@ Server function called: \code{cbindDS}
 
 }
 \author{
-DataSHIELD Development Team
+Paul Burton and Demetris Avraam for DataSHIELD Development Team
 }


### PR DESCRIPTION
The function now 1) removes any $ signs if any from the column names, 2) specifies the column names in the correct order as the corresponding order of the variables in each study, 3) generates a dataframe instead of a matrix, 4) has additional checks to check it the number of rows are the same in all the components to cbind and if any column names are duplicated. Also additional examples were added in the headers