### PR TITLE
Permit perf test duration to be set, seconds, by environment variable…

### DIFF
--- a/tests/testthat/perf_tests/perf_rate.R
+++ b/tests/testthat/perf_tests/perf_rate.R
@@ -57,6 +57,11 @@ perf.reference.save <- function(perf.ref.name, rate, tolerance.lower, tolerance.
     .perf.reference <<- .perf.reference
 }
 
+# Obtain performance test duration from PERF_DURATION_SEC environment variable, otherwise default.duration argument, otherwise "30".
+perf.testduration <- function(default.duration = 30) {
+    base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = base::as.character(default.duration)))
+}
+
 perf.reference.rate <- function(perf.ref.name) {
     if (is.null(.perf.reference))
         .load.pref()

--- a/tests/testthat/test-perf-conndisconn.R
+++ b/tests/testthat/test-perf-conndisconn.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -22,7 +22,7 @@ disconnect.studies.dataset.cnsim()
 
 # context("conndisconn::perf::simple0")
 test_that("simple connect - disconnect performance", {
-    .durationSec  <- 120 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "120")) # defaults to 120 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-conndisconn.R
+++ b/tests/testthat/test-perf-conndisconn.R
@@ -22,7 +22,7 @@ disconnect.studies.dataset.cnsim()
 
 # context("conndisconn::perf::simple0")
 test_that("simple connect - disconnect performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "120")) # defaults to 120 seconds
+    .durationSec  <- perf.testduration(120)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.abs.R
+++ b/tests/testthat/test-perf-ds.abs.R
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.abs::perf:0")
 test_that("combine - performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.abs.R
+++ b/tests/testthat/test-perf-ds.abs.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.abs::perf:0")
 test_that("combine - performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.asInteger.R
+++ b/tests/testthat/test-perf-ds.asInteger.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("GENDER"))
 
 # context("ds.asInteger::perf:0")
 test_that("combine - performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.asInteger.R
+++ b/tests/testthat/test-perf-ds.asInteger.R
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("GENDER"))
 
 # context("ds.asInteger::perf:0")
 test_that("combine - performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.asList.R
+++ b/tests/testthat/test-perf-ds.asList.R
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.asList::perf:0")
 test_that("combine - performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.asList.R
+++ b/tests/testthat/test-perf-ds.asList.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.asList::perf:0")
 test_that("combine - performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.asNumeric.R
+++ b/tests/testthat/test-perf-ds.asNumeric.R
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("GENDER"))
 
 # context("ds.asNumeric::perf:0")
 test_that("combine - performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.asNumeric.R
+++ b/tests/testthat/test-perf-ds.asNumeric.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("GENDER"))
 
 # context("ds.asNumeric::perf:0")
 test_that("combine - performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.assign.R
+++ b/tests/testthat/test-perf-ds.assign.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.assign::perf::0")
 test_that("performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.assign.R
+++ b/tests/testthat/test-perf-ds.assign.R
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.assign::perf::0")
 test_that("performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.class.R
+++ b/tests/testthat/test-perf-ds.class.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.class::perf::combine:0")
 test_that("combine - performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.class.R
+++ b/tests/testthat/test-perf-ds.class.R
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.class::perf::combine:0")
 test_that("combine - performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.colnames.R
+++ b/tests/testthat/test-perf-ds.colnames.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.colnames::perf:0")
 test_that("combine - performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.colnames.R
+++ b/tests/testthat/test-perf-ds.colnames.R
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.colnames::perf:0")
 test_that("combine - performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.exists.R
+++ b/tests/testthat/test-perf-ds.exists.R
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.exists::perf::combine:0")
 test_that("combine - performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.exists.R
+++ b/tests/testthat/test-perf-ds.exists.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.exists::perf::combine:0")
 test_that("combine - performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.length.R
+++ b/tests/testthat/test-perf-ds.length.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.length::perf::combine:0")
 test_that("combine - performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.length.R
+++ b/tests/testthat/test-perf-ds.length.R
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.length::perf::combine:0")
 test_that("combine - performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.mean.R
+++ b/tests/testthat/test-perf-ds.mean.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.mean::perf::combine:0")
 test_that("combine - performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time
@@ -52,7 +52,7 @@ test_that("combine - performance", {
 
 # context("ds.mean::perf::split:0")
 test_that("split - performance", {
-    .durationSec  <- 30 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-ds.mean.R
+++ b/tests/testthat/test-perf-ds.mean.R
@@ -21,7 +21,7 @@ connect.studies.dataset.cnsim(list("LAB_TSC", "LAB_TRIG"))
 
 # context("ds.mean::perf::combine:0")
 test_that("combine - performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time
@@ -52,7 +52,7 @@ test_that("combine - performance", {
 
 # context("ds.mean::perf::split:0")
 test_that("split - performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "30")) # defaults to 30 seconds
+    .durationSec  <- perf.testduration(30)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-void.R
+++ b/tests/testthat/test-perf-void.R
@@ -1,5 +1,5 @@
 #-------------------------------------------------------------------------------
-# Copyright (c) 2024-2025 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
+# Copyright (c) 2024-2026 Arjuna Technologies, Newcastle upon Tyne. All rights reserved.
 #
 # This program and the accompanying materials
 # are made available under the terms of the GNU Public License v3.0.
@@ -20,7 +20,7 @@
 
 # context("void::perf::void::0")
 test_that("simple void performance", {
-    .durationSec  <- 60 # seconds
+    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "60")) # defaults to 60 seconds
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time

--- a/tests/testthat/test-perf-void.R
+++ b/tests/testthat/test-perf-void.R
@@ -20,7 +20,7 @@
 
 # context("void::perf::void::0")
 test_that("simple void performance", {
-    .durationSec  <- base::as.integer(base::Sys.getenv("PERF_DURATION_SEC", unset = "60")) # defaults to 60 seconds
+    .durationSec  <- perf.testduration(60)
     .count        <- 0
     .start.time   <- Sys.time()
     .current.time <- .start.time


### PR DESCRIPTION
Can use environment variable 'PERF_DURATION_SEC', in seconds, to specify individual test's duration. 