### PR TITLE
feat: support remote Armadillo URLs via local_settings.csv

### DIFF
--- a/tests/testthat/connection_to_datasets/init_discordant_datasets.R
+++ b/tests/testthat/connection_to_datasets/init_discordant_datasets.R
@@ -5,17 +5,17 @@ init.discordant.dataset.simple <- function(variables)
       if (ds.test_env$driver == "OpalDriver")
       {
         builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-        builder$append(server = "discordant1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "DISCORDANT.DISCORDANT_STUDY1", options=ds.test_env$options_1)
-        builder$append(server = "discordant2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "DISCORDANT.DISCORDANT_STUDY2", options=ds.test_env$options_2)
-        builder$append(server = "discordant3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "DISCORDANT.DISCORDANT_STUDY3", options=ds.test_env$options_3)
+        builder$append(server = "discordant1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "DISCORDANT.DISCORDANT_STUDY1", options=ds.test_env$options_1)
+        builder$append(server = "discordant2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "DISCORDANT.DISCORDANT_STUDY2", options=ds.test_env$options_2)
+        builder$append(server = "discordant3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "DISCORDANT.DISCORDANT_STUDY3", options=ds.test_env$options_3)
         ds.test_env$login.data <- builder$build()
       }
       else if (ds.test_env$driver == "ArmadilloDriver")
       {
         builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-        builder$append(server = "discordant1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/discordant/DISCORDANT_STUDY1", driver = "ArmadilloDriver")
-        builder$append(server = "discordant2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/discordant/DISCORDANT_STUDY2", driver = "ArmadilloDriver")
-        builder$append(server = "discordant3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/discordant/DISCORDANT_STUDY3", driver = "ArmadilloDriver")
+        builder$append(server = "discordant1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/discordant/DISCORDANT_STUDY1", driver = "ArmadilloDriver")
+        builder$append(server = "discordant2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/discordant/DISCORDANT_STUDY2", driver = "ArmadilloDriver")
+        builder$append(server = "discordant3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/discordant/DISCORDANT_STUDY3", driver = "ArmadilloDriver")
         ds.test_env$login.data <- builder$build()
       }
       else 

--- a/tests/testthat/connection_to_datasets/init_local_settings.R
+++ b/tests/testthat/connection_to_datasets/init_local_settings.R
@@ -1,28 +1,33 @@
-#this file stores some settings for the continuous integration and local testing.
+#
+# The file "connection_to_datasets/local_settings.csv" (within the directory "tests/testthat") contains, if present,
+# values which can be used to affect the behavious of the continuous integration.
+#
+# The server URL is in a CVS file, being the value of the first column, first row.
+#
 
-init.ip.address <- function()
+init.server.url <- function()
 {
    file.name <- init.local.settings()
    if (file.exists(file.name))
    {
-      content <- read.csv(file.name, header = FALSE)
-      ip.address <- as.character(content[[1]][1])
+      content    <- read.csv(file.name, header = FALSE)
+      server.url <- as.character(content[[1]][1])
    }
    else
    {
-      # ip.address <- "127.0.0.1"
-      ip.address <- "localhost"
+      # server.url <- "http://127.0.0.1:8080/"
+      server.url <- "http://localhost:8080/"
    }
-   return (ip.address)
+   return (server.url)
 }
 
 
 
 init.local.settings <- function()
 {
-  path <- getwd()
+  path            <- getwd()
   sub.folder.name <- "/connection_to_datasets/"
-  file.name <- "local_settings.csv"
-  return(paste(path, sub.folder.name,file.name, sep=""))
-  
+  file.name       <- "local_settings.csv"
+
+  return(paste(path, sub.folder.name, file.name, sep=""))
 }

--- a/tests/testthat/connection_to_datasets/init_mediation_datasets.R
+++ b/tests/testthat/connection_to_datasets/init_mediation_datasets.R
@@ -5,9 +5,9 @@ init.mediation.dataset.upb <- function(variables)
         if (ds.test_env$driver == "OpalDriver")
         {
             builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-            builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "MEDIATION.UPBdata1", options=ds.test_env$options_1)
-            builder$append(server = "study2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "MEDIATION.UPBdata2", options=ds.test_env$options_2)
-            builder$append(server = "study3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "MEDIATION.UPBdata3", options=ds.test_env$options_3)
+            builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "MEDIATION.UPBdata1", options=ds.test_env$options_1)
+            builder$append(server = "study2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "MEDIATION.UPBdata2", options=ds.test_env$options_2)
+            builder$append(server = "study3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "MEDIATION.UPBdata3", options=ds.test_env$options_3)
             ds.test_env$login.data <- builder$build()
         }
         else 
@@ -25,7 +25,7 @@ init.mediation.dataset.student <- function(variables)
         if (ds.test_env$driver == "OpalDriver")
         {
             builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-            builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "MEDIATION.student", options=ds.test_env$options_1)
+            builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "MEDIATION.student", options=ds.test_env$options_1)
             ds.test_env$login.data <- builder$build()
         }
         else 
@@ -43,7 +43,7 @@ init.mediation.dataset.framing <- function(variables)
         if (ds.test_env$driver == "OpalDriver")
         {
             builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-            builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "MEDIATION.framing", options=ds.test_env$options_1)
+            builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "MEDIATION.framing", options=ds.test_env$options_1)
             ds.test_env$login.data <- builder$build()
         }
         else 
@@ -61,7 +61,7 @@ init.mediation.dataset.vv2015 <- function(variables)
         if (ds.test_env$driver == "OpalDriver")
         {
             builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-            builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "MEDIATION.vv2015", options=ds.test_env$options_1)
+            builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "MEDIATION.vv2015", options=ds.test_env$options_1)
             ds.test_env$login.data <- builder$build()
         }
         else 

--- a/tests/testthat/connection_to_datasets/init_studies_datasets.R
+++ b/tests/testthat/connection_to_datasets/init_studies_datasets.R
@@ -5,17 +5,17 @@ init.studies.dataset.cnsim <- function(variables)
       if (ds.test_env$driver == "OpalDriver")
       {
         builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-        builder$append(server = "sim1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "CNSIM.CNSIM1", options=ds.test_env$options_1)
-        builder$append(server = "sim2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "CNSIM.CNSIM2", options=ds.test_env$options_2)
-        builder$append(server = "sim3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "CNSIM.CNSIM3", options=ds.test_env$options_3)
+        builder$append(server = "sim1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "CNSIM.CNSIM1", options=ds.test_env$options_1)
+        builder$append(server = "sim2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "CNSIM.CNSIM2", options=ds.test_env$options_2)
+        builder$append(server = "sim3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "CNSIM.CNSIM3", options=ds.test_env$options_3)
         ds.test_env$login.data <- builder$build()
       }
       else if (ds.test_env$driver == "ArmadilloDriver")
       {
         builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-        builder$append(server = "sim1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/cnsim/CNSIM1", driver = ds.test_env$driver)
-        builder$append(server = "sim2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/cnsim/CNSIM2", driver = ds.test_env$driver)
-        builder$append(server = "sim3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/cnsim/CNSIM3", driver = ds.test_env$driver)
+        builder$append(server = "sim1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/cnsim/CNSIM1", driver = ds.test_env$driver)
+        builder$append(server = "sim2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/cnsim/CNSIM2", driver = ds.test_env$driver)
+        builder$append(server = "sim3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/cnsim/CNSIM3", driver = ds.test_env$driver)
         ds.test_env$login.data <- builder$build()
       }
       else 
@@ -33,17 +33,17 @@ init.studies.dataset.dasim <- function(variables)
       if (ds.test_env$driver == "OpalDriver")
       {
         builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-        builder$append(server = "sim1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "DASIM.DASIM1", options=ds.test_env$options_1)
-        builder$append(server = "sim2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "DASIM.DASIM2", options=ds.test_env$options_2)
-        builder$append(server = "sim3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "DASIM.DASIM3", options=ds.test_env$options_3)
+        builder$append(server = "sim1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "DASIM.DASIM1", options=ds.test_env$options_1)
+        builder$append(server = "sim2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "DASIM.DASIM2", options=ds.test_env$options_2)
+        builder$append(server = "sim3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "DASIM.DASIM3", options=ds.test_env$options_3)
         ds.test_env$login.data <- builder$build()
       }
       else if (ds.test_env$driver == "ArmadilloDriver")
       {
         builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-        builder$append(server = "sim1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/dasim/DASIM1", driver = ds.test_env$driver)
-        builder$append(server = "sim2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/dasim/DASIM2", driver = ds.test_env$driver)
-        builder$append(server = "sim3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/dasim/DASIM3", driver = ds.test_env$driver)
+        builder$append(server = "sim1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/dasim/DASIM1", driver = ds.test_env$driver)
+        builder$append(server = "sim2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/dasim/DASIM2", driver = ds.test_env$driver)
+        builder$append(server = "sim3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/dasim/DASIM3", driver = ds.test_env$driver)
         ds.test_env$login.data <- builder$build()
       }
       else 
@@ -61,17 +61,17 @@ init.studies.dataset.survival <- function(variables)
       if (ds.test_env$driver == "OpalDriver")
       {
         builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-        builder$append(server = "survival1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "SURVIVAL.EXPAND_WITH_MISSING1", options=ds.test_env$options_1)
-        builder$append(server = "survival2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "SURVIVAL.EXPAND_WITH_MISSING2", options=ds.test_env$options_2)
-        builder$append(server = "survival3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "SURVIVAL.EXPAND_WITH_MISSING3", options=ds.test_env$options_3)
+        builder$append(server = "survival1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "SURVIVAL.EXPAND_WITH_MISSING1", options=ds.test_env$options_1)
+        builder$append(server = "survival2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "SURVIVAL.EXPAND_WITH_MISSING2", options=ds.test_env$options_2)
+        builder$append(server = "survival3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "SURVIVAL.EXPAND_WITH_MISSING3", options=ds.test_env$options_3)
         ds.test_env$login.data <- builder$build()
       }
       else if (ds.test_env$driver == "ArmadilloDriver")
       {
         builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-        builder$append(server = "survival1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/survival/EXPAND_WITH_MISSING1", driver = ds.test_env$driver)
-        builder$append(server = "survival2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/survival/EXPAND_WITH_MISSING2", driver = ds.test_env$driver)
-        builder$append(server = "survival3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/survival/EXPAND_WITH_MISSING3", driver = ds.test_env$driver)
+        builder$append(server = "survival1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/survival/EXPAND_WITH_MISSING1", driver = ds.test_env$driver)
+        builder$append(server = "survival2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/survival/EXPAND_WITH_MISSING2", driver = ds.test_env$driver)
+        builder$append(server = "survival3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/survival/EXPAND_WITH_MISSING3", driver = ds.test_env$driver)
         ds.test_env$login.data <- builder$build()
       }
       else 
@@ -94,17 +94,17 @@ init.studies.dataset.cluster.int <- function(variables)
     if (ds.test_env$driver == "OpalDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "cluster.int1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "CLUSTER.CLUSTER_INT1", options=ds.test_env$options_1)
-      builder$append(server = "cluster.int2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "CLUSTER.CLUSTER_INT2", options=ds.test_env$options_2)
-      builder$append(server = "cluster.int3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "CLUSTER.CLUSTER_INT3", options=ds.test_env$options_3)
+      builder$append(server = "cluster.int1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "CLUSTER.CLUSTER_INT1", options=ds.test_env$options_1)
+      builder$append(server = "cluster.int2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "CLUSTER.CLUSTER_INT2", options=ds.test_env$options_2)
+      builder$append(server = "cluster.int3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "CLUSTER.CLUSTER_INT3", options=ds.test_env$options_3)
       ds.test_env$login.data <- builder$build()
     }
     else if (ds.test_env$driver == "ArmadilloDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "cluster.int1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/cluster/CLUSTER_INT1", driver = ds.test_env$driver)
-      builder$append(server = "cluster.int2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/cluster/CLUSTER_INT2", driver = ds.test_env$driver)
-      builder$append(server = "cluster.int3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/cluster/CLUSTER_INT3", driver = ds.test_env$driver)
+      builder$append(server = "cluster.int1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/cluster/CLUSTER_INT1", driver = ds.test_env$driver)
+      builder$append(server = "cluster.int2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/cluster/CLUSTER_INT2", driver = ds.test_env$driver)
+      builder$append(server = "cluster.int3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/cluster/CLUSTER_INT3", driver = ds.test_env$driver)
       ds.test_env$login.data <- builder$build()
     }
     else 
@@ -128,17 +128,17 @@ init.studies.dataset.cluster.slo <- function(variables)
     if (ds.test_env$driver == "OpalDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "cluster.slo1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "CLUSTER.CLUSTER_SLO1", options=ds.test_env$options_1)
-      builder$append(server = "cluster.slo2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "CLUSTER.CLUSTER_SLO2", options=ds.test_env$options_2)
-      builder$append(server = "cluster.slo3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "CLUSTER.CLUSTER_SLO3", options=ds.test_env$options_3)
+      builder$append(server = "cluster.slo1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "CLUSTER.CLUSTER_SLO1", options=ds.test_env$options_1)
+      builder$append(server = "cluster.slo2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "CLUSTER.CLUSTER_SLO2", options=ds.test_env$options_2)
+      builder$append(server = "cluster.slo3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "CLUSTER.CLUSTER_SLO3", options=ds.test_env$options_3)
       ds.test_env$login.data <- builder$build()
     }
     else if (ds.test_env$driver == "ArmadilloDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "cluster.slo1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/cluster/CLUSTER_SLO1", driver = ds.test_env$driver)
-      builder$append(server = "cluster.slo2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/cluster/CLUSTER_SLO2", driver = ds.test_env$driver)
-      builder$append(server = "cluster.slo3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/cluster/CLUSTER_SLO3", driver = ds.test_env$driver)
+      builder$append(server = "cluster.slo1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/cluster/CLUSTER_SLO1", driver = ds.test_env$driver)
+      builder$append(server = "cluster.slo2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/cluster/CLUSTER_SLO2", driver = ds.test_env$driver)
+      builder$append(server = "cluster.slo3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/cluster/CLUSTER_SLO3", driver = ds.test_env$driver)
       ds.test_env$login.data <- builder$build()
     }
     else 
@@ -163,17 +163,17 @@ init.studies.dataset.anthro <- function(variables)
     if (ds.test_env$driver == "OpalDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "ANTHRO.anthro1", options=ds.test_env$options_1)
-      builder$append(server = "study2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "ANTHRO.anthro2", options=ds.test_env$options_2)
-      builder$append(server = "study3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "ANTHRO.anthro3", options=ds.test_env$options_3)
+      builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "ANTHRO.anthro1", options=ds.test_env$options_1)
+      builder$append(server = "study2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "ANTHRO.anthro2", options=ds.test_env$options_2)
+      builder$append(server = "study3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "ANTHRO.anthro3", options=ds.test_env$options_3)
       ds.test_env$login.data <- builder$build()
     }
     else if (ds.test_env$driver == "ArmadilloDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/anthro/anthro1", driver = ds.test_env$driver)
-      builder$append(server = "study2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/anthro/anthro2", driver = ds.test_env$driver)
-      builder$append(server = "study3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/anthro/anthro3", driver = ds.test_env$driver)
+      builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/anthro/anthro1", driver = ds.test_env$driver)
+      builder$append(server = "study2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/anthro/anthro2", driver = ds.test_env$driver)
+      builder$append(server = "study3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/anthro/anthro3", driver = ds.test_env$driver)
       ds.test_env$login.data <- builder$build()
     }
     else 
@@ -198,17 +198,17 @@ init.studies.dataset.gamlss <- function(variables)
     if (ds.test_env$driver == "OpalDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "GAMLSS.gamlss1", options=ds.test_env$options_1)
-      builder$append(server = "study2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "GAMLSS.gamlss2", options=ds.test_env$options_2)
-      builder$append(server = "study3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "GAMLSS.gamlss3", options=ds.test_env$options_3)
+      builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "GAMLSS.gamlss1", options=ds.test_env$options_1)
+      builder$append(server = "study2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "GAMLSS.gamlss2", options=ds.test_env$options_2)
+      builder$append(server = "study3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "GAMLSS.gamlss3", options=ds.test_env$options_3)
       ds.test_env$login.data <- builder$build()
     }
     else if (ds.test_env$driver == "ArmadilloDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/gamlss/gamlss1", driver = ds.test_env$driver)
-      builder$append(server = "study2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/gamlss/gamlss2", driver = ds.test_env$driver)
-      builder$append(server = "study3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/gamlss/gamlss3", driver = ds.test_env$driver)
+      builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/gamlss/gamlss1", driver = ds.test_env$driver)
+      builder$append(server = "study2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/gamlss/gamlss2", driver = ds.test_env$driver)
+      builder$append(server = "study3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/gamlss/gamlss3", driver = ds.test_env$driver)
       ds.test_env$login.data <- builder$build()
     }
     else 

--- a/tests/testthat/connection_to_datasets/init_testing_datasets.R
+++ b/tests/testthat/connection_to_datasets/init_testing_datasets.R
@@ -21,17 +21,17 @@ init.testing.datasets <- function()
     if (ds.test_env$driver == "OpalDriver") 
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "TESTING.DATASET1", options=ds.test_env$options_1)
-      builder$append(server = "study2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "TESTING.DATASET2", options=ds.test_env$options_2)
-      builder$append(server = "study3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "TESTING.DATASET3", options=ds.test_env$options_3)
+      builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "TESTING.DATASET1", options=ds.test_env$options_1)
+      builder$append(server = "study2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "TESTING.DATASET2", options=ds.test_env$options_2)
+      builder$append(server = "study3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "TESTING.DATASET3", options=ds.test_env$options_3)
       ds.test_env$login.data <- builder$build()
     }
     else if (ds.test_env$driver == "ArmadilloDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/testing/DATASET1", driver = "ArmadilloDriver")
-      builder$append(server = "study2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/testing/DATASET2", driver = "ArmadilloDriver")
-      builder$append(server = "study3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/testing/DATASET3", driver = "ArmadilloDriver")
+      builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/testing/DATASET1", driver = "ArmadilloDriver")
+      builder$append(server = "study2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/testing/DATASET2", driver = "ArmadilloDriver")
+      builder$append(server = "study3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/testing/DATASET3", driver = "ArmadilloDriver")
       ds.test_env$login.data <- builder$build()
     }
     else 
@@ -56,13 +56,13 @@ init.dataset.3 <- function()
     if (ds.test_env$driver == "OpalDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "TESTING.DATASET3", options=ds.test_env$options_3)
+      builder$append(server = "study3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "TESTING.DATASET3", options=ds.test_env$options_3)
       ds.test_env$login.data <- builder$build()
     }
     else if (ds.test_env$driver == "ArmadilloDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study3", url = ds.test_env$ip_address_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/testing/DATASET3", driver = "ArmadilloDriver")
+      builder$append(server = "study3", url = ds.test_env$server_url_3, user = ds.test_env$user_3, password = ds.test_env$password_3, table = "datashield/testing/DATASET3", driver = "ArmadilloDriver")
       ds.test_env$login.data <- builder$build()
     }
     else
@@ -88,13 +88,13 @@ init.dataset.2 <- function()
     if (ds.test_env$driver == "OpalDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "TESTING.DATASET2", options=ds.test_env$options_2)
+      builder$append(server = "study2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "TESTING.DATASET2", options=ds.test_env$options_2)
       ds.test_env$login.data <- builder$build()
     }
     else if (ds.test_env$driver == "ArmadilloDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study2", url = ds.test_env$ip_address_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/testing/DATASET2", driver = "ArmadilloDriver")
+      builder$append(server = "study2", url = ds.test_env$server_url_2, user = ds.test_env$user_2, password = ds.test_env$password_2, table = "datashield/testing/DATASET2", driver = "ArmadilloDriver")
       ds.test_env$login.data <- builder$build()
     }
     else
@@ -120,13 +120,13 @@ init.dataset.1 <- function()
     if (ds.test_env$driver == "OpalDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "TESTING.DATASET1", options=ds.test_env$options_1)
+      builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "TESTING.DATASET1", options=ds.test_env$options_1)
       ds.test_env$login.data <- builder$build()
     }
     else if (ds.test_env$driver == "ArmadilloDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "study1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/testing/DATASET1", driver = "ArmadilloDriver")
+      builder$append(server = "study1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/testing/DATASET1", driver = "ArmadilloDriver")
       ds.test_env$login.data <- builder$build()
     }
     else
@@ -159,17 +159,17 @@ init.testing.dataset.factor_levels <- function()
     if (ds.test_env$driver == "OpalDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "GROUP1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "FACTOR_LEVELS.FACTOR_LEVELS1", options=ds.test_env$options_1)
-      builder$append(server = "GROUP2", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "FACTOR_LEVELS.FACTOR_LEVELS2", options=ds.test_env$options_2)
-      builder$append(server = "GROUP3", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "FACTOR_LEVELS.FACTOR_LEVELS3", options=ds.test_env$options_3)
+      builder$append(server = "GROUP1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "FACTOR_LEVELS.FACTOR_LEVELS1", options=ds.test_env$options_1)
+      builder$append(server = "GROUP2", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "FACTOR_LEVELS.FACTOR_LEVELS2", options=ds.test_env$options_2)
+      builder$append(server = "GROUP3", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "FACTOR_LEVELS.FACTOR_LEVELS3", options=ds.test_env$options_3)
       ds.test_env$login.data <- builder$build()
     }
     else if (ds.test_env$driver == "ArmadilloDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "GROUP1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/factor_levels/FACTOR_LEVELS1", driver = "ArmadilloDriver")
-      builder$append(server = "GROUP2", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/factor_levels/FACTOR_LEVELS2", driver = "ArmadilloDriver")
-      builder$append(server = "GROUP3", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/factor_levels/FACTOR_LEVELS3", driver = "ArmadilloDriver")
+      builder$append(server = "GROUP1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/factor_levels/FACTOR_LEVELS1", driver = "ArmadilloDriver")
+      builder$append(server = "GROUP2", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/factor_levels/FACTOR_LEVELS2", driver = "ArmadilloDriver")
+      builder$append(server = "GROUP3", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/factor_levels/FACTOR_LEVELS3", driver = "ArmadilloDriver")
       ds.test_env$login.data <- builder$build()
     }
     else
@@ -192,13 +192,13 @@ init.testing.dataset.factor_levels.1 <- function()
     if (ds.test_env$driver == "OpalDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "GROUP1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "FACTOR_LEVELS.FACTOR_LEVELS1", options=ds.test_env$options_1)
+      builder$append(server = "GROUP1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "FACTOR_LEVELS.FACTOR_LEVELS1", options=ds.test_env$options_1)
       ds.test_env$login.data <- builder$build()
     }
     else if (ds.test_env$driver == "ArmadilloDriver")
     {
       builder <- DSI::newDSLoginBuilder(.silent = TRUE)
-      builder$append(server = "GROUP1", url = ds.test_env$ip_address_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/factor_levels/FACTOR_LEVELS1", driver = "ArmadilloDriver")
+      builder$append(server = "GROUP1", url = ds.test_env$server_url_1, user = ds.test_env$user_1, password = ds.test_env$password_1, table = "datashield/factor_levels/FACTOR_LEVELS1", driver = "ArmadilloDriver")
       ds.test_env$login.data <- builder$build()
     }
     else

--- a/tests/testthat/connection_to_datasets/login_details.R
+++ b/tests/testthat/connection_to_datasets/login_details.R
@@ -22,12 +22,18 @@ if (! is.null(getOption("default_driver"))) {
 }
 
 if ((ds.test_env$driver == "DSLiteDriver") || (ds.test_env$driver == "OpalDriver")) {
-    ds.test_env$ping_address <- paste("https://", ds.test_env$server_ip_address, ":8443", sep="")
+    if (ds.test_env$server_ip_address == "localhost") {
+        opal.url <- "https://localhost:8443"
+    } else {
+        opal.url <- ds.test_env$server_ip_address
+    }
+
+    ds.test_env$ping_address <- opal.url
     ds.test_env$ping_config  <- config(timeout=5, ssl_verifyhost=0, ssl_verifypeer=0)
 
-    ds.test_env$ip_address_1 <- paste("https://", ds.test_env$server_ip_address, ":8443", sep="")
-    ds.test_env$ip_address_2 <- paste("https://", ds.test_env$server_ip_address, ":8443", sep="")
-    ds.test_env$ip_address_3 <- paste("https://", ds.test_env$server_ip_address, ":8443", sep="")
+    ds.test_env$ip_address_1 <- opal.url
+    ds.test_env$ip_address_2 <- opal.url
+    ds.test_env$ip_address_3 <- opal.url
 
     ds.test_env$user_1 <- getOption("opal.user", "administrator")
     ds.test_env$user_2 <- getOption("opal.user", "administrator")

--- a/tests/testthat/connection_to_datasets/login_details.R
+++ b/tests/testthat/connection_to_datasets/login_details.R
@@ -2,7 +2,7 @@
 
 source("connection_to_datasets/init_local_settings.R")
 
-init.ip.address()
+init.server.url()
 
 # create blank environment of test data
 ds.test_env <- new.env()
@@ -10,7 +10,7 @@ ds.test_env <- new.env()
 # this option helps DSI to find the connection objects by looking in the right environment
 options(datashield.env=ds.test_env)
 
-ds.test_env$server_ip_address <- init.ip.address()
+ds.test_env$server_server_url <- init.server.url()
 
 if (! is.null(getOption("default_driver"))) {
     ds.test_env$driver <- getOption("default_driver")
@@ -22,18 +22,14 @@ if (! is.null(getOption("default_driver"))) {
 }
 
 if ((ds.test_env$driver == "DSLiteDriver") || (ds.test_env$driver == "OpalDriver")) {
-    if (ds.test_env$server_ip_address == "localhost") {
-        opal.url <- "https://localhost:8443"
-    } else {
-        opal.url <- ds.test_env$server_ip_address
-    }
+    opal.url <- ds.test_env$server_url
 
-    ds.test_env$ping_address <- opal.url
-    ds.test_env$ping_config  <- config(timeout=5, ssl_verifyhost=0, ssl_verifypeer=0)
+    ds.test_env$ping_url     <- opal.url
+    ds.test_env$ping_config  <- config(timeout=5)
 
-    ds.test_env$ip_address_1 <- opal.url
-    ds.test_env$ip_address_2 <- opal.url
-    ds.test_env$ip_address_3 <- opal.url
+    ds.test_env$server_url_1 <- opal.url
+    ds.test_env$server_url_2 <- opal.url
+    ds.test_env$server_url_3 <- opal.url
 
     ds.test_env$user_1 <- getOption("opal.user", "administrator")
     ds.test_env$user_2 <- getOption("opal.user", "administrator")
@@ -43,24 +39,20 @@ if ((ds.test_env$driver == "DSLiteDriver") || (ds.test_env$driver == "OpalDriver
     ds.test_env$password_2 <- getOption("opal.password", "datashield_test&")
     ds.test_env$password_3 <- getOption("opal.password", "datashield_test&")
 
-    ds.test_env$options_1 <- "list(ssl_verifyhost=0, ssl_verifypeer=0)"
-    ds.test_env$options_2 <- "list(ssl_verifyhost=0, ssl_verifypeer=0)"
-    ds.test_env$options_3 <- "list(ssl_verifyhost=0, ssl_verifypeer=0)"
+    ds.test_env$options_1 <- "list()"
+    ds.test_env$options_2 <- "list()"
+    ds.test_env$options_3 <- "list()"
 
     ds.test_env$secure_login_details <- TRUE
 } else if (ds.test_env$driver == "ArmadilloDriver") {
-    if (ds.test_env$server_ip_address == "localhost") {
-        armadillo.url <- "http://localhost:8080"
-    } else {
-        armadillo.url <- ds.test_env$server_ip_address
-    }
+    armadillo.url <- ds.test_env$server_url
 
-    ds.test_env$ping_address <- armadillo.url
+    ds.test_env$ping_url     <- armadillo.url
     ds.test_env$ping_config  <- config(timeout=5)
 
-    ds.test_env$ip_address_1 <- armadillo.url
-    ds.test_env$ip_address_2 <- armadillo.url
-    ds.test_env$ip_address_3 <- armadillo.url
+    ds.test_env$server_url_1 <- armadillo.url
+    ds.test_env$server_url_2 <- armadillo.url
+    ds.test_env$server_url_3 <- armadillo.url
 
     ds.test_env$user_1 <- getOption("armadillo.user", "admin")
     ds.test_env$user_2 <- getOption("armadillo.user", "admin")

--- a/tests/testthat/connection_to_datasets/login_details.R
+++ b/tests/testthat/connection_to_datasets/login_details.R
@@ -10,7 +10,7 @@ ds.test_env <- new.env()
 # this option helps DSI to find the connection objects by looking in the right environment
 options(datashield.env=ds.test_env)
 
-ds.test_env$server_server_url <- init.server.url()
+ds.test_env$server_url <- init.server.url()
 
 if (! is.null(getOption("default_driver"))) {
     ds.test_env$driver <- getOption("default_driver")

--- a/tests/testthat/connection_to_datasets/login_details.R
+++ b/tests/testthat/connection_to_datasets/login_details.R
@@ -43,20 +43,26 @@ if ((ds.test_env$driver == "DSLiteDriver") || (ds.test_env$driver == "OpalDriver
 
     ds.test_env$secure_login_details <- TRUE
 } else if (ds.test_env$driver == "ArmadilloDriver") {
-    ds.test_env$ping_address <- paste("http://", ds.test_env$server_ip_address, ":8080", sep="")
+    if (ds.test_env$server_ip_address == "localhost") {
+        armadillo.url <- "http://localhost:8080"
+    } else {
+        armadillo.url <- ds.test_env$server_ip_address
+    }
+
+    ds.test_env$ping_address <- armadillo.url
     ds.test_env$ping_config  <- config(timeout=5)
 
-    ds.test_env$ip_address_1 <- paste("http://", ds.test_env$server_ip_address, ":8080", sep="")
-    ds.test_env$ip_address_2 <- paste("http://", ds.test_env$server_ip_address, ":8080", sep="")
-    ds.test_env$ip_address_3 <- paste("http://", ds.test_env$server_ip_address, ":8080", sep="")
+    ds.test_env$ip_address_1 <- armadillo.url
+    ds.test_env$ip_address_2 <- armadillo.url
+    ds.test_env$ip_address_3 <- armadillo.url
 
-    ds.test_env$user_1 <- getOption("opal.user", "admin")
-    ds.test_env$user_2 <- getOption("opal.user", "admin")
-    ds.test_env$user_3 <- getOption("opal.user", "admin")
+    ds.test_env$user_1 <- getOption("armadillo.user", "admin")
+    ds.test_env$user_2 <- getOption("armadillo.user", "admin")
+    ds.test_env$user_3 <- getOption("armadillo.user", "admin")
 
-    ds.test_env$password_1 <- getOption("opal.password", "admin")
-    ds.test_env$password_2 <- getOption("opal.password", "admin")
-    ds.test_env$password_3 <- getOption("opal.password", "admin")
+    ds.test_env$password_1 <- getOption("armadillo.password", "admin")
+    ds.test_env$password_2 <- getOption("armadillo.password", "admin")
+    ds.test_env$password_3 <- getOption("armadillo.password", "admin")
 
     ds.test_env$options_1 <- "list()"
     ds.test_env$options_2 <- "list()"

--- a/tests/testthat/test-_-vm-test.R
+++ b/tests/testthat/test-_-vm-test.R
@@ -26,7 +26,7 @@ init.testing.datasets()
 
 test_that("The virtual machine is loaded. ",
 {
-    response <- httr::HEAD(url=ds.test_env$ping_address, config=ds.test_env$ping_config)
+    response <- httr::HEAD(url=ds.test_env$ping_url, config=ds.test_env$ping_config)
     expect_true(http_status(response)$reason %in% c("OK", "Unauthorized"))
 })
 


### PR DESCRIPTION
## Background
Existing logic to construct armadillo url only works for localhost. To do performance testing we need to use a remote server to simualte real life conditions.

## What's changed
If URL specified in `local_settings` is localhost it constructs url, for all other urls it uses as-is.

## How to test
- [ ] Code Review